### PR TITLE
refactor: stop calling spring_config_default()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ Also check the changes in springql-core: <https://github.com/SpringQL/SpringQL/b
 <!-- markdownlint-disable MD024 -->
 ## [Unreleased]
 
+### For developers
+
+- refactor: stop calling spring_config_default(). ([#43](https://github.com/SpringQL/SpringQL-client-c/pull/43))
+
 ## [v0.11.0]
 
 ### For developers

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,7 +34,7 @@ use ::springql_core::api::{error::SpringError, SpringPipeline as Pipeline};
 /// If you would like to change the default configuration, use `spring_config_toml()` instead.
 #[no_mangle]
 pub extern "C" fn spring_config_default() -> *mut SpringConfig {
-    let config = ::springql_core::api::spring_config_default();
+    let config = ::springql_core::api::SpringConfig::default();
     SpringConfig::new(config).into_ptr()
 }
 
@@ -413,7 +413,7 @@ pub unsafe extern "C" fn spring_column_bool(
 /// - `CNull`: Column value is NULL.
 #[no_mangle]
 pub unsafe extern "C" fn spring_column_float(
-row: *const SpringRow,
+    row: *const SpringRow,
     i_col: u16,
     out: *mut c_float,
 ) -> SpringErrno {


### PR DESCRIPTION
## Issue number and link

## Describe your changes

I will remove `fn spring_config_default()` in SpringQL repo.

## Checklist before requesting a review

- [x] I follow the [Semantic Pull Requests](https://github.com/zeke/semantic-pull-requests) rules (bugfix/feature)
- [ ] I specified links to related issues (must: bugfix, want: feature)
- [x] I have performed a self-review of my code (bugfix/feature)
- [ ] I have added thorough tests (bugfix/feature)
- [x] I have edited `## [Unreleased]` section in `CHANGELOG.md` following [keep a changelog](https://keepachangelog.com/en/1.0.0/) syntax (bugfix/feature)
- [ ] I {made/will make} a related pull request for [documentation repo](https://github.com/SpringQL/SpringQL.github.io) (feature)
