### PR TITLE
fix: CInsufficient check for memcpy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,11 +13,17 @@ Also check the changes in springql-core: <https://github.com/SpringQL/SpringQL/b
 <!-- markdownlint-disable MD024 -->
 ## [Unreleased]
 
+## [v0.13.0+3]
+
+### Fixed
+
+- `spring_column_blob()`'s `out_len` check. ([#46](https://github.com/SpringQL/SpringQL-client-c/pull/46))
+
 ## [v0.13.0+2]
 
 ### Added
 
-- add include guard to `springql.h`. ([#46](https://github.com/SpringQL/SpringQL-client-c/pull/46))
+- add include guard to `springql.h`. ([#47](https://github.com/SpringQL/SpringQL-client-c/pull/47))
 
 ## [v0.13.0]
 
@@ -67,8 +73,10 @@ Depends on springql-core v0.7.1.
 [Semantic Versioning]: https://semver.org/
 
 <!-- Versions -->
-[Unreleased]: https://github.com/SpringQL/SpringQL-client-c/compare/v0.13.0...HEAD
+[Unreleased]: https://github.com/SpringQL/SpringQL-client-c/compare/v0.13.0+3...HEAD
 [Released]: https://github.com/SpringQL/SpringQL-client-c/releases
+[v0.13.0+3]: https://github.com/SpringQL/SpringQL-client-c/compare/v0.13.0+2...v0.13.0+3
+[v0.13.0+2]: https://github.com/SpringQL/SpringQL-client-c/compare/v0.13.0...v0.13.0+2
 [v0.13.0]: https://github.com/SpringQL/SpringQL-client-c/compare/v0.12.0...v0.13.0
 [v0.12.0]: https://github.com/SpringQL/SpringQL-client-c/compare/v0.11.0...v0.12.0
 [v0.11.0]: https://github.com/SpringQL/SpringQL-client-c/compare/v0.9.0+2...v0.11.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,13 +17,13 @@ Also check the changes in springql-core: <https://github.com/SpringQL/SpringQL/b
 
 ### Fixed
 
-- `spring_column_blob()`'s `out_len` check. ([#46](https://github.com/SpringQL/SpringQL-client-c/pull/46))
+- `spring_column_blob()`'s `out_len` check. ([#47](https://github.com/SpringQL/SpringQL-client-c/pull/47))
 
 ## [v0.13.0+2]
 
 ### Added
 
-- add include guard to `springql.h`. ([#47](https://github.com/SpringQL/SpringQL-client-c/pull/47))
+- add include guard to `springql.h`. ([#46](https://github.com/SpringQL/SpringQL-client-c/pull/46))
 
 ## [v0.13.0]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "springql-client-c"
-version = "0.13.0+2"
+version = "0.13.0+3"
 
 authors = ["Sho Nakatani <lay.sakura@gmail.com>"]
 license = "MIT OR Apache-2.0"

--- a/src/c_mem.rs
+++ b/src/c_mem.rs
@@ -1,8 +1,9 @@
 // This file is part of https://github.com/SpringQL/SpringQL-client-c which is licensed under MIT OR Apache-2.0. See file LICENSE-MIT or LICENSE-APACHE for full license details.
 
 use std::{
+    ffi::c_void,
     os::raw::{c_char, c_int},
-    ptr, slice, ffi::c_void,
+    ptr, slice,
 };
 
 use log::warn;
@@ -15,6 +16,7 @@ use crate::spring_errno::SpringErrno;
 /// - `< 0`: SpringErrno
 pub(super) fn strcpy(src: &str, dest_buf: *mut c_char, dest_len: c_int) -> c_int {
     if src.len() >= dest_len as usize {
+        // `==` is not sufficient (dest needs null termination)
         warn!("dest_len is smaller than src.");
         warn!(
             "Expected at least {} bytes but got {}",
@@ -41,13 +43,9 @@ pub(super) fn strcpy(src: &str, dest_buf: *mut c_char, dest_len: c_int) -> c_int
 /// - `> 0`: the length of `src`.
 /// - `< 0`: SpringErrno
 pub(super) fn memcpy(src: &[u8], dest_buf: *mut c_void, dest_len: c_int) -> c_int {
-    if src.len() >= dest_len as usize {
+    if src.len() > dest_len as usize {
         warn!("dest_len is smaller than src.");
-        warn!(
-            "Expected at least {} bytes but got {}",
-            src.len() + 1,
-            dest_len
-        );
+        warn!("Expected at least {} bytes but got {}", src.len(), dest_len);
         return SpringErrno::CInsufficient as c_int;
     }
 


### PR DESCRIPTION
## Issue number and link

<!--- For bugfix, you must link to at least an issue to show clear way to reproduce the bug. -->

<!--- For new feature without any related issues, include your motivation in the next section -->

## Describe your changes

`spring_column_blob()` returned `CInsufficient` error when the source and the dest buffer have the same length.

## Checklist before requesting a review

- [x] I follow the [Semantic Pull Requests](https://github.com/zeke/semantic-pull-requests) rules (bugfix/feature)
- [ ] I specified links to related issues (must: bugfix, want: feature)
- [x] I have performed a self-review of my code (bugfix/feature)
- [ ] I have added thorough tests (bugfix/feature)
- [x] I have edited `## [Unreleased]` section in `CHANGELOG.md` following [keep a changelog](https://keepachangelog.com/en/1.0.0/) syntax (bugfix/feature)
- [ ] I {made/will make} a related pull request for [documentation repo](https://github.com/SpringQL/SpringQL.github.io) (feature)
