### PR TITLE
fix: memcpy's trailing null-termination

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,12 @@ Also check the changes in springql-core: <https://github.com/SpringQL/SpringQL/b
 <!-- markdownlint-disable MD024 -->
 ## [Unreleased]
 
+## [v0.13.0+4]
+
+### Fixed
+
+- `spring_column_blob()` mistakenly adds trailing null-termination to dest buffer. ([#48](https://github.com/SpringQL/SpringQL-client-c/pull/48))
+
 ## [v0.13.0+3]
 
 ### Fixed
@@ -73,8 +79,9 @@ Depends on springql-core v0.7.1.
 [Semantic Versioning]: https://semver.org/
 
 <!-- Versions -->
-[Unreleased]: https://github.com/SpringQL/SpringQL-client-c/compare/v0.13.0+3...HEAD
+[Unreleased]: https://github.com/SpringQL/SpringQL-client-c/compare/v0.13.0+4...HEAD
 [Released]: https://github.com/SpringQL/SpringQL-client-c/releases
+[v0.13.0+4]: https://github.com/SpringQL/SpringQL-client-c/compare/v0.13.0+2...v0.13.0+4
 [v0.13.0+3]: https://github.com/SpringQL/SpringQL-client-c/compare/v0.13.0+2...v0.13.0+3
 [v0.13.0+2]: https://github.com/SpringQL/SpringQL-client-c/compare/v0.13.0...v0.13.0+2
 [v0.13.0]: https://github.com/SpringQL/SpringQL-client-c/compare/v0.12.0...v0.13.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "springql-client-c"
-version = "0.13.0+3"
+version = "0.13.0+4"
 
 authors = ["Sho Nakatani <lay.sakura@gmail.com>"]
 license = "MIT OR Apache-2.0"

--- a/src/c_mem.rs
+++ b/src/c_mem.rs
@@ -54,9 +54,5 @@ pub(super) fn memcpy(src: &[u8], dest_buf: *mut c_void, dest_len: c_int) -> c_in
         ptr::copy_nonoverlapping(src.as_ptr(), buffer.as_mut_ptr(), src.len());
     }
 
-    // Add a trailing null so people using the string as a `char *` don't
-    // accidentally read into garbage.
-    buffer[src.len()] = 0;
-
     src.len() as c_int
 }


### PR DESCRIPTION
## Issue number and link

<!--- For bugfix, you must link to at least an issue to show clear way to reproduce the bug. -->

<!--- For new feature without any related issues, include your motivation in the next section -->

## Describe your changes

memcpy treats binary data so it must not add trailing NULL byte.

## Checklist before requesting a review

- [x] I follow the [Semantic Pull Requests](https://github.com/zeke/semantic-pull-requests) rules (bugfix/feature)
- [ ] I specified links to related issues (must: bugfix, want: feature)
- [x] I have performed a self-review of my code (bugfix/feature)
- [ ] I have added thorough tests (bugfix/feature)
- [x] I have edited `## [Unreleased]` section in `CHANGELOG.md` following [keep a changelog](https://keepachangelog.com/en/1.0.0/) syntax (bugfix/feature)
- [ ] I {made/will make} a related pull request for [documentation repo](https://github.com/SpringQL/SpringQL.github.io) (feature)
