### PR TITLE
fix: free SpringSourceRowBuilder inside spring_source_row_build()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,12 @@ Also check the changes in springql-core: <https://github.com/SpringQL/SpringQL/b
 <!-- markdownlint-disable MD024 -->
 ## [Unreleased]
 
+## [v0.16.0+3] - 2022-07-11
+
+### Fixed
+
+- Memory leak of `SpringSourceRowBuilder` ([#58](https://github.com/SpringQL/SpringQL-client-c/pull/58))
+
 ## [v0.16.0+2] - 2022-07-06
 
 ### Added
@@ -118,8 +124,9 @@ Depends on springql-core v0.7.1.
 [Semantic Versioning]: https://semver.org/
 
 <!-- Versions -->
-[Unreleased]: https://github.com/SpringQL/SpringQL-client-c/compare/v0.16.0+2...HEAD
+[Unreleased]: https://github.com/SpringQL/SpringQL-client-c/compare/v0.16.0+3...HEAD
 [Released]: https://github.com/SpringQL/SpringQL-client-c/releases
+[v0.16.0+3]: https://github.com/SpringQL/SpringQL-client-c/compare/v0.16.0+2...v0.16.0+3
 [v0.16.0+2]: https://github.com/SpringQL/SpringQL-client-c/compare/v0.16.0...v0.16.0+2
 [v0.16.0]: https://github.com/SpringQL/SpringQL-client-c/compare/v0.15.0+2...v0.16.0
 [v0.15.0+2]: https://github.com/SpringQL/SpringQL-client-c/compare/v0.15.0...v0.15.0+2

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1044,7 +1044,7 @@ dependencies = [
 
 [[package]]
 name = "springql-client-c"
-version = "0.16.0"
+version = "0.16.0+2"
 dependencies = [
  "cbindgen",
  "log",

--- a/springql.h
+++ b/springql.h
@@ -232,6 +232,8 @@ enum SpringErrno spring_source_row_add_column_blob(SpringSourceRowBuilder *build
 /**
  * Finish creating a source row using a builder.
  *
+ * The heap space for the `builder` is internally freed.
+ *
  * # Returns
  *
  * SpringSourceRow

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -305,6 +305,8 @@ pub unsafe extern "C" fn spring_source_row_add_column_blob(
 }
 /// Finish creating a source row using a builder.
 ///
+/// The heap space for the `builder` is internally freed.
+///
 /// # Returns
 ///
 /// SpringSourceRow
@@ -313,7 +315,9 @@ pub unsafe extern "C" fn spring_source_row_build(
     builder: *mut SpringSourceRowBuilder,
 ) -> *mut SpringSourceRow {
     let rust_builder = (*builder).to_row_builder();
-    SpringSourceRow::new(rust_builder.build()).into_ptr()
+    let ret = SpringSourceRow::new(rust_builder.build()).into_ptr();
+    SpringSourceRowBuilder::drop(builder);
+    ret
 }
 
 /// Frees heap occupied by a `SpringSourceRow`.


### PR DESCRIPTION
## Issue number and link

Related to: https://github.com/SpringQL/SpringQL-client-c/issues/59

(but the demo app does not use SpringSourceRowBuilder)

## Describe your changes

T/O

## Checklist before requesting a review

- [x] I follow the [Semantic Pull Requests](https://github.com/zeke/semantic-pull-requests) rules (bugfix/feature)
- [x] I specified links to related issues (must: bugfix, want: feature)
- [x] I have performed a self-review of my code (bugfix/feature)
- [ ] I have added thorough tests (bugfix/feature)
- [x] I have edited `## [Unreleased]` section in `CHANGELOG.md` following [keep a changelog](https://keepachangelog.com/en/1.0.0/) syntax (bugfix/feature)
- [ ] I {made/will make} a related pull request for [documentation repo](https://github.com/SpringQL/SpringQL.github.io) (feature)
